### PR TITLE
Check config for triggering command on clear cache event

### DIFF
--- a/src/AssetsServiceProvider.php
+++ b/src/AssetsServiceProvider.php
@@ -42,7 +42,7 @@ class AssetsServiceProvider extends ServiceProvider
         $this->commands('escapework.asset.command');
 
         $this->app['events']->listen('cache:cleared', function() use($app) {
-            if ($app->environment() !== 'local') {
+            if (in_array($app->environment(), $app['config']->get('assets.environments'))) {
                 Artisan::call('asset:dist');
             }
         });


### PR DESCRIPTION
Hello,

I got a case when setting environment set to local, asset key is not generated after `cache:cleared` event. Even when `local` environment is registered is set to `local`. I think the `cache:cleared` event listener should also check the config file, so that for any environment set in the config, the `asset:dist` will be triggered when cache cleared.

Best Regards