### PR TITLE
Fix command unit test

### DIFF
--- a/tests/EscapeWork/Assets/Console/AssetDistCommandTest.php
+++ b/tests/EscapeWork/Assets/Console/AssetDistCommandTest.php
@@ -27,7 +27,7 @@ class AssetDistCommandTest extends \PHPUnit_Framework_TestCase
         $command->shouldReceive('unlinkOldDirectories')->once()->with($types, '12345');
         $command->shouldReceive('createDistDirectories')->once($types, m::any());
 
-        $command->fire();
+        $command->handle();
     }
 
     public function test_update_config_version_with_published_config()


### PR DESCRIPTION
I found undefined function call in the unit test, fixed that:

* replace `fire` with `handle` function call

Best Regards